### PR TITLE
fix page前缀的中括号被过滤

### DIFF
--- a/src/core/bilibili.ts
+++ b/src/core/bilibili.ts
@@ -359,7 +359,7 @@ const getSubtitle = async (cid: number, bvid: string) => {
 // 处理filePathList
 const handleFilePathList = (page: number, title: string, up: string, bvid: string, id: string): string[] => {
   const downloadPath = store.settingStore().downloadPath
-  const name = filterTitle(`${!page ? '' : `[P${page}]`}${title}-${up}-${bvid}-${id}`)
+  const name = `${!page ? '' : `[P${page}]`}${filterTitle(`${title}-${up}-${bvid}-${id}`)}`
   const isFolder = store.settingStore().isFolder
   return [
     `${downloadPath}/${isFolder ? `${name}/` : ''}${name}.mp4`,
@@ -373,7 +373,7 @@ const handleFilePathList = (page: number, title: string, up: string, bvid: strin
 // 处理fileDir
 const handleFileDir = (page: number, title: string, up: string, bvid: string, id: string): string => {
   const downloadPath = store.settingStore().downloadPath
-  const name = filterTitle(`${!page ? '' : `[P${page}]`}${title}-${up}-${bvid}-${id}`)
+  const name = `${!page ? '' : `[P${page}]`}${filterTitle(`${title}-${up}-${bvid}-${id}`)}`
   const isFolder = store.settingStore().isFolder
   return `${downloadPath}${isFolder ? `/${name}/` : ''}`
 }


### PR DESCRIPTION
今天下载一个分P视频时视频本身有数字编号，下载以后和软件添加的`Pxx`重合到了一起（P1变为了P11），排序就出问题了。
看到代码中这个前缀是有中括号包围的，但是被filterTitle给过滤掉了。
这个应该是不用过滤的，否则没必要在代码中加入中括号。

这里，我把前缀放到了filterTitle方法的外边。

另外，我觉得可以根据总的page数量，编号的长度固定会更好一些。