### PR TITLE
fix: ep类型需要'回到旧版'才能正常解析

### DIFF
--- a/src/core/bilibili.ts
+++ b/src/core/bilibili.ts
@@ -138,18 +138,18 @@ const checkUrl = (url: string) => {
 }
 
 // 检查url是否有重定向
-const checkUrlRedirect = async (videoUrl: string) => {
+const checkUrlRedirect = async (videoUrl: string, videoType: string) => {
   const params = {
     videoUrl,
     config: {
       headers: {
         'User-Agent': `${UA}`,
-        cookie: `SESSDATA=${store.settingStore(pinia).SESSDATA}`
+        cookie: `SESSDATA=${store.settingStore(pinia).SESSDATA}${videoType === 'ep' ? '; go-old-ogv-video=1' : ''}`
       }
     }
   }
   const { body, redirectUrls } = await window.electron.got(params.videoUrl, params.config)
-  const url = redirectUrls[0] ? redirectUrls[0] : videoUrl
+  const url = redirectUrls[0] || videoUrl
   return {
     body,
     url

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -71,7 +71,7 @@ const download = async () => {
     }
   }
   // 检查是否有重定向
-  const { body, url } = await checkUrlRedirect(videoUrl.value)
+  const { body, url } = await checkUrlRedirect(videoUrl.value, videoType)
   // 解析html
   try {
     const videoInfo = await parseHtml(body, videoType, url)


### PR DESCRIPTION
相关issue: #130 , #123.
ep页面有这样的图标来切换'新版'和'旧版'
![image](https://github.com/BilibiliVideoDownload/BilibiliVideoDownload/assets/5477995/037d9493-40a2-4750-9866-9751685e2cfe)
默认(至少我的账户)会来到新版, 会导致 https://github.com/BilibiliVideoDownload/BilibiliVideoDownload/blob/a061112da83a3f6a6aa77380357b8d5cadc617af/src/core/bilibili.ts#L172-L175 函数出错
貌似在cookies中加上`go-old-ogv-video=1`就可以来到旧版.

烦请会搭建项目的大佬们测试一下, 测试网址: https://www.bilibili.com/bangumi/play/ep744054 , 非常感谢.

