### PR TITLE
fix: 修复 parse bv error 和 playurl 412 风控，恢复视频下载

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "hx-*"
+  workflow_dispatch:
 
 # Workflow's jobs
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ pnpm-debug.log*
 
 #Electron-builder output
 /dist_electron
+/cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -13696,7 +13696,7 @@
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16593,8 +16593,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@vue/cli-plugin-vuex/-/cli-plugin-vuex-5.0.4.tgz",
       "integrity": "sha512-dBwiD6mT9+V2HTHcwaWE8qFNgTk5I/NUvxYVeUN3Mmmpo4y/1RxXnr7BlKGnaQsTypb2RFk3KowqIJtg7s+E3Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@vue/cli-service": {
       "version": "5.0.4",
@@ -17136,15 +17135,13 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -17189,8 +17186,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -18608,8 +18604,7 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.2.2.tgz",
       "integrity": "sha512-Ufadglr88ZLsrvS11gjeu/40Lw74D9Am/Jpr3LlYm5Q4ZP5KdlUhG+6u2EjyXeZcxmZ2h1ebCKngDjolpeLHpg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "css-loader": {
       "version": "6.7.1",
@@ -18751,8 +18746,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-3.1.0.tgz",
       "integrity": "sha512-JQNR19/YZhz4psLX/rQ9M83e3z2Wf/HdJbryzte4a3NSuafyp9w/I4U+hx5C2S9g41qlstH7DEWnZaaj83OuEA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "csso": {
       "version": "4.2.0",
@@ -19820,8 +19814,7 @@
       "version": "16.0.3",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz",
       "integrity": "sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -20016,8 +20009,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-5.2.0.tgz",
       "integrity": "sha512-SftLb1pUG01QYq2A/hGAWfDRXqYD82zE7j7TopDOyNdU+7SvvoXREls/+PRTY17vUXzXnZA/zfnyKgRH6x4JJw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-vue": {
       "version": "8.7.1",
@@ -21285,8 +21277,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -23440,29 +23431,25 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-5.1.1.tgz",
       "integrity": "sha512-5JscyFmvkUxz/5/+TB3QTTT9Gi9jHkcn8dcmmuN68JQcv3aQg4y88yEHHhwFB52l/NkaJ43O0dbksGMAo49nfQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-duplicates": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-5.1.0.tgz",
       "integrity": "sha512-zmX3IoSI2aoenxHV6C7plngHWWhUOV3sP1T8y2ifzxzbtnuhk1EdPwm0S1bIUNaJ2eNbWeGLEwzw8huPD67aQw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-empty": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-5.1.1.tgz",
       "integrity": "sha512-zPz4WljiSuLWsI0ir4Mcnr4qQQ5e1Ukc3i7UfE2XcrwKK2LIPIqE5jxMRxO6GbI3cv//ztXDsXwEWT3BHOGh3A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-discard-overridden": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-5.1.0.tgz",
       "integrity": "sha512-21nOL7RqWR1kasIVdKs8HNqQJhFxLsyRfAnUDm4Fe4t4mCWL9OJiHvlHPjcd8zc5Myu89b/7wZDnOSjFgeWRtw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-loader": {
       "version": "6.2.1",
@@ -23556,8 +23543,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -23592,8 +23578,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-5.1.0.tgz",
       "integrity": "sha512-mSgUJ+pd/ldRGVx26p2wz9dNZ7ji6Pn8VWBajMXFf8jk7vUoSrZ2lt/wZR7DtlZYKesmZI680qjr2CeFF2fbUg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-normalize-display-values": {
       "version": "5.1.0",
@@ -25536,7 +25521,7 @@
       "version": "4.5.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
       "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==",
-      "devOptional": true
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -25835,8 +25820,7 @@
     "vue-demi": {
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.5.tgz",
-      "integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==",
-      "requires": {}
+      "integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q=="
     },
     "vue-eslint-parser": {
       "version": "8.3.0",
@@ -26311,8 +26295,7 @@
           "version": "8.7.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.7.0.tgz",
           "integrity": "sha512-c2gsP0PRwcLFzUiA8Mkr37/MI7ilIlHQxaEAtd0uNMbVMoy8puJyafRlm0bV9MbGSabUPeLrRRaqIBcFcA2Pqg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -26477,8 +26460,7 @@
       "version": "7.5.8",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.8.tgz",
       "integrity": "sha512-ri1Id1WinAX5Jqn9HejiGb8crfRio0Qgu8+MtL36rlTA6RLsMdWt1Az/19A2Qij6uSHUMphEFaTKa4WG+UNHNw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/src/background.ts
+++ b/src/background.ts
@@ -3,6 +3,7 @@
 import { app, protocol, BrowserWindow, ipcMain, shell, dialog, Menu, globalShortcut } from 'electron'
 import { createProtocol } from 'vue-cli-plugin-electron-builder/lib'
 import installExtension, { VUEJS3_DEVTOOLS } from 'electron-devtools-installer'
+import { execFile } from 'child_process'
 import path from 'path'
 import fs from 'fs-extra'
 import { settingData } from './assets/data/default'
@@ -11,6 +12,7 @@ import downloadVideo from './core/download'
 const Store = require('electron-store')
 const got = require('got')
 const log = require('electron-log')
+const crypto = require('crypto')
 
 const store = new Store({
   name: 'database'
@@ -89,7 +91,7 @@ ipcMain.handle('got', (event, url, option) => {
         return resolve({ body: res.body, redirectUrls: res.redirectUrls, headers: res.headers })
       })
       .catch((error: any) => {
-        log.error(`http error: ${error.message}`)
+        log.error(`http error [${url}]: ${error.message}`)
         return reject(error.message)
       })
   })
@@ -104,9 +106,44 @@ ipcMain.handle('got-buffer', (event, url, option) => {
         return resolve(res)
       })
       .catch((error: any) => {
-        log.error(`http error: ${error.message}`)
+        log.error(`http error [${url}]: ${error.message}`)
         return reject(error.message)
       })
+  })
+})
+
+// md5 签名（渲染进程 wbi 抗风控用）
+ipcMain.handle('md5', (event, str: string) => {
+  return crypto.createHash('md5').update(str).digest('hex')
+})
+
+// 调用 yt-dlp 获取视频信息（绕过 got 库的 TLS 指纹风控）
+ipcMain.handle('ytdlp-info', async (event, url: string, sessdata: string) => {
+  return new Promise((resolve, reject) => {
+    const cookieFile = path.join(app.getPath('temp'), `bili_cookie_${Date.now()}.txt`)
+    try {
+      const content = sessdata
+        ? `# Netscape HTTP Cookie File\n.bilibili.com\tTRUE\t/\tTRUE\t0\tSESSDATA\t${sessdata}\n`
+        : ''
+      fs.writeFileSync(cookieFile, content, 'utf8')
+    } catch (e: any) {
+      return reject('写 cookie 文件失败')
+    }
+    const args = ['-m', 'yt_dlp', '-J', '--no-warnings', '--no-playlist', '--no-call-home']
+    if (sessdata) args.push('--cookies', cookieFile)
+    args.push(url)
+    execFile('python', args, { encoding: 'utf8', maxBuffer: 50 * 1024 * 1024, timeout: 120000, windowsHide: true }, (err: any, stdout: string) => {
+      try { fs.removeSync(cookieFile) } catch (e) {}
+      if (err) {
+        log.error(`yt-dlp error: ${err.message}`)
+        return reject(err.message || 'yt-dlp 执行失败')
+      }
+      try {
+        resolve(JSON.parse(stdout))
+      } catch (e: any) {
+        reject('yt-dlp 输出解析失败')
+      }
+    })
   })
 })
 

--- a/src/core/bilibili.ts
+++ b/src/core/bilibili.ts
@@ -100,12 +100,109 @@ const saveResponseCookies = (cookies: string[]) => {
  *
  * @returns 0: 游客，未登录 1：普通用户 2：大会员
  */
-const checkLogin = async (SESSDATA: string) => {
+// ============ wbi 签名 + buvid3 抗风控（规避 B站 412 风控）============
+// wbi 混淆表（B站公开固定表）
+const MIXIN_KEY_ENC_TAB = [
+  46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35,
+  27, 43, 22, 1, 30, 11, 8, 3, 43, 12, 52, 57, 13, 62, 29, 55,
+  61, 8, 9, 60, 14, 41, 53, 24, 19, 19, 53, 61, 26, 39, 50, 25,
+  15, 9, 7, 4, 6, 36, 33, 28, 22, 51, 14, 44, 49, 35, 16, 46
+]
+// 缓存 wbi mixin_key 与 buvid3，避免每次请求重复拉取
+let wbiMixinKeyCache: string | null = null
+let buvid3Cache: string | null = null
+
+// 构造完整浏览器请求头 + 抗风控 cookie（buvid3 是 B站反爬关键指纹）
+const buildHeaders = (sessdata?: string): any => {
+  const SESSDATA = sessdata !== undefined ? sessdata : store.settingStore(pinia).SESSDATA
+  const bfeId = store.settingStore(pinia).bfeId
+  let cookie = `SESSDATA=${SESSDATA};bfe_id=${bfeId}`
+  if (buvid3Cache) cookie += `;buvid3=${buvid3Cache}`
+  return {
+    'User-Agent': `${UA}`,
+    Referer: 'https://www.bilibili.com/',
+    Origin: 'https://www.bilibili.com',
+    'Accept-Language': 'zh-CN,zh;q=0.9',
+    cookie
+  }
+}
+
+// 获取 buvid3（finger/spi 接口，B站反爬关键指纹）
+const ensureBuvid3 = async (): Promise<void> => {
+  if (buvid3Cache) return
+  // 参考 yt-dlp：本地生成 buvid3（uuid4 + 'infoc'），不依赖 finger/spi（该接口在风控环境也 412，且其下发的 buvid3 可能被标记）
+  const hex = '0123456789abcdef'
+  let u = ''
+  for (let i = 0; i < 36; i++) {
+    if (i === 8 || i === 13 || i === 18 || i === 23) u += '-'
+    else if (i === 14) u += '4'
+    else if (i === 19) u += hex[8 + Math.floor(Math.random() * 4)]
+    else u += hex[Math.floor(Math.random() * 16)]
+  }
+  buvid3Cache = u + 'infoc'
+}
+
+// 获取 wbi mixin_key（nav 接口的 wbi_img）
+const ensureWbiMixinKey = async (): Promise<string> => {
+  if (wbiMixinKeyCache) return wbiMixinKeyCache
   const { body } = await window.electron.got('https://api.bilibili.com/x/web-interface/nav', {
-    headers: {
-      'User-Agent': `${UA}`,
-      cookie: `SESSDATA=${SESSDATA}`
-    },
+    headers: buildHeaders(),
+    responseType: 'json'
+  })
+  if (body.code !== 0 || !body.data || !body.data.wbi_img) throw new Error('获取 wbi 密钥失败')
+  const imgKey = body.data.wbi_img.img_url.split('/').pop()!.split('.')[0]
+  const subKey = body.data.wbi_img.sub_url.split('/').pop()!.split('.')[0]
+  const raw = imgKey + subKey
+  let mixinKey = ''
+  for (const i of MIXIN_KEY_ENC_TAB) {
+    mixinKey += raw[i]
+  }
+  wbiMixinKeyCache = mixinKey.slice(0, 32)
+  return wbiMixinKeyCache
+}
+
+// 生成 B站 playurl 反风控设备指纹参数（参考 yt-dlp _dm_params，源自 bili-user-fingerprint.min.js）
+const PRINTABLE = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!"#$%&\'()*+,-./:;<=>?@[\\]^_`{|}~ \t\n\r\x0b\x0c'
+const genDmParams = (): Record<string, string> => {
+  const randStr = (min: number, max: number) => {
+    const k = Math.floor(Math.random() * (max - min + 1)) + min
+    let s = ''
+    for (let i = 0; i < k; i++) s += PRINTABLE[Math.floor(Math.random() * PRINTABLE.length)]
+    return s
+  }
+  const b64 = (min: number, max: number) => btoa(randStr(min, max)).slice(0, -2)
+  const rnd114 = () => Math.floor(114 * Math.random())
+  const rnd514 = () => Math.floor(514 * Math.random())
+  const wh = [2 * 1920 + 2 * 1080 + 3 * rnd114(), 4 * 1920 - 1080 + rnd114(), rnd114()]
+  const ofRnd = Math.floor(Math.random() * 101)
+  const of = [3 * ofRnd + rnd514(), 4 * ofRnd + 2 * rnd514(), rnd514()]
+  return {
+    dm_img_list: '[]',
+    dm_img_str: b64(16, 64),
+    dm_cover_img_str: b64(32, 128),
+    dm_img_inter: JSON.stringify({ ds: [], wh, of })
+  }
+}
+
+// 对请求参数做 wbi 签名，返回带 wts + w_rid 的完整 query string
+const encWbi = async (params: Record<string, any>): Promise<string> => {
+  const mixinKey = await ensureWbiMixinKey()
+  const signed: Record<string, string> = {}
+  for (const k of Object.keys(params)) {
+    // 过滤 wbi 不支持的字符
+    signed[k] = String(params[k]).replace(/[!'()*]/g, '')
+  }
+  signed.wts = String(Math.floor(Date.now() / 1000))
+  const keys = Object.keys(signed).sort()
+  const query = keys.map(k => `${k}=${encodeURIComponent(signed[k])}`).join('&')
+  const wRid = await window.electron.md5(query + mixinKey)
+  return `${query}&w_rid=${wRid}`
+}
+
+const checkLogin = async (SESSDATA: string) => {
+  await ensureBuvid3()
+  const { body } = await window.electron.got('https://api.bilibili.com/x/web-interface/nav', {
+    headers: buildHeaders(SESSDATA),
     responseType: 'json'
   })
   if (body.data.isLogin && !body.data.vipStatus) {
@@ -139,20 +236,16 @@ const checkUrl = (url: string) => {
 
 // 检查url是否有重定向
 const checkUrlRedirect = async (videoUrl: string) => {
-  const params = {
-    videoUrl,
-    config: {
-      headers: {
-        'User-Agent': `${UA}`,
-        cookie: `SESSDATA=${store.settingStore(pinia).SESSDATA}`
-      }
-    }
-  }
-  const { body, redirectUrls } = await window.electron.got(params.videoUrl, params.config)
-  const url = redirectUrls[0] ? redirectUrls[0] : videoUrl
-  return {
-    body,
-    url
+  await ensureBuvid3()
+  try {
+    const { body, redirectUrls } = await window.electron.got(videoUrl, {
+      headers: buildHeaders()
+    })
+    const url = redirectUrls[0] ? redirectUrls[0] : videoUrl
+    return { body, url }
+  } catch (e: any) {
+    // 网页请求被风控(412)时降级：parseBV 只需从 url 提取 BV，不依赖 body
+    return { body: '', url: videoUrl }
   }
 }
 
@@ -169,44 +262,58 @@ const parseHtml = (html: string, type: string, url: string) => {
   }
 }
 
-const parseBV = async (html: string, url: string) => {
+// 从url中提取BV号或av号
+const extractVideoId = (url: string): { bvid?: string, aid?: string } => {
+  const bvMatch = url.match(/\/(BV[a-zA-Z0-9]{10})/)
+  if (bvMatch) return { bvid: bvMatch[1] }
+  const avMatch = url.match(/\/av(\d+)/i)
+  if (avMatch) return { aid: avMatch[1] }
+  return {}
+}
+
+// 通过官方API获取视频信息
+// 不再依赖网页HTML中的__INITIAL_STATE__解析，规避B站改版/风控导致的解析失败
+const getViewInfo = async (bvid?: string, aid?: string): Promise<any> => {
+  await ensureBuvid3()
+  const params = bvid ? { bvid } : { aid }
+  const query = await encWbi(params as Record<string, any>)
+  const { body, headers: { 'set-cookie': responseCookies } } = await window.electron.got(
+    `https://api.bilibili.com/x/web-interface/view?${query}`,
+    { headers: buildHeaders(), responseType: 'json' }
+  )
+  if (body.code !== 0) throw new Error(`获取视频信息失败: ${body.message}`)
+  // 保存返回的cookies
+  saveResponseCookies(responseCookies)
+  return body.data
+}
+
+const parseBV = async (_html: string, url: string) => {
   try {
-    const videoInfo = html.match(/\<\/script\>\<script\>window\.\_\_INITIAL\_STATE\_\_\=([\s\S]*?)\;\(function\(\)/)
-    if (!videoInfo) throw new Error('parse bv error')
-    const { videoData } = JSON.parse(videoInfo[1])
+    // 从url提取BV/av号，调用官方API获取视频信息（不再解析HTML）
+    const { bvid, aid } = extractVideoId(url)
+    if (!bvid && !aid) throw new Error('parse bv error')
+    const data: any = await getViewInfo(bvid, aid)
     // 获取视频下载地址
-    let acceptQuality = null
-    try {
-      let downLoadData: any = html.match(/\<script\>window\.\_\_playinfo\_\_\=([\s\S]*?)\<\/script\>\<script\>window\.\_\_INITIAL\_STATE\_\_\=/)
-      if (!downLoadData) throw new Error('parse bv error')
-      downLoadData = JSON.parse(downLoadData[1])
-      acceptQuality = {
-        accept_quality: downLoadData.data.accept_quality,
-        video: downLoadData.data.dash.video,
-        audio: downLoadData.data.dash.audio
-      }
-    } catch (error) {
-      acceptQuality = await getAcceptQuality(videoData.cid, videoData.bvid)
-    }
+    const acceptQuality = await getAcceptQuality(data.cid, data.bvid)
     const obj: VideoData = {
       id: '',
-      title: videoData.title,
+      title: data.title,
       url,
-      bvid: videoData.bvid,
-      cid: videoData.cid,
-      cover: videoData.pic,
+      bvid: data.bvid,
+      cid: data.cid,
+      cover: data.pic,
       createdTime: -1,
       quality: -1,
-      view: videoData.stat.view,
-      danmaku: videoData.stat.danmaku,
-      reply: videoData.stat.reply,
-      duration: formatSeconed(videoData.duration),
-      up: videoData.hasOwnProperty('staff') ? videoData.staff.map((item: any) => ({ name: item.name, mid: item.mid })) : [{ name: videoData.owner.name, mid: videoData.owner.mid }],
+      view: data.stat.view,
+      danmaku: data.stat.danmaku,
+      reply: data.stat.reply,
+      duration: formatSeconed(data.duration),
+      up: data.hasOwnProperty('staff') ? data.staff.map((item: any) => ({ name: item.name, mid: item.mid })) : [{ name: data.owner.name, mid: data.owner.mid }],
       qualityOptions: acceptQuality.accept_quality.map((item: any) => ({ label: qualityMap[item], value: item })),
-      page: parseBVPageData(videoData, url),
+      page: parseBVPageData({ bvid: data.bvid, title: data.title, pages: data.pages }, url),
       subtitle: [],
-      video: acceptQuality.video ? acceptQuality.video.map((item: any) => ({ id: item.id, cid: videoData.cid, url: item.baseUrl })) : [],
-      audio: acceptQuality.audio ? acceptQuality.audio.map((item: any) => ({ id: item.id, cid: videoData.cid, url: item.baseUrl })) : [],
+      video: acceptQuality.video ? acceptQuality.video.map((item: any) => ({ id: item.id, cid: data.cid, url: item.baseUrl })) : [],
+      audio: acceptQuality.audio ? acceptQuality.audio.map((item: any) => ({ id: item.id, cid: data.cid, url: item.baseUrl })) : [],
       filePathList: [],
       fileDir: '',
       size: -1,
@@ -292,45 +399,45 @@ const parseSS = async (html: string) => {
   }
 }
 
-// 获取视频清晰度列表
+// 调用 yt-dlp 获取视频流信息（绕过 got 库请求 playurl 时的 TLS 指纹风控）
+const getYtdlpFormats = async (bvid: string): Promise<{ accept_quality: number[], video: any[], audio: any[] }> => {
+  const sessdata = store.settingStore(pinia).SESSDATA
+  const url = `https://www.bilibili.com/video/${bvid}`
+  const info: any = await window.electron.ytdlpInfo(url, sessdata)
+  const formats: any[] = info.formats || []
+  // video 流：按 quality 分组，avc1(H.264 兼容性最好) 优先于 hev1
+  const videoMap = new Map<number, any>()
+  for (const f of formats) {
+    if (f.vcodec && f.vcodec !== 'none' && f.quality) {
+      const q = f.quality
+      const exist = videoMap.get(q)
+      if (!exist || (f.vcodec.startsWith('avc1') && !exist.vcodec.startsWith('avc1'))) {
+        videoMap.set(q, f)
+      }
+    }
+  }
+  const video = Array.from(videoMap.values()).map((f: any) => ({ id: f.quality, baseUrl: f.url }))
+  // audio 流：format_id 越大码率越高（getHighQualityAudio 按 id 降序取最高）
+  const audio = formats
+    .filter((f: any) => f.acodec && f.acodec !== 'none')
+    .map((f: any) => ({ id: parseInt(f.format_id) || 0, baseUrl: f.url }))
+    .sort((a: any, b: any) => b.id - a.id)
+  const accept_quality = Array.from(videoMap.keys()).sort((a: number, b: number) => b - a)
+  return { accept_quality, video, audio }
+}
+
+// 获取视频清晰度列表（改用 yt-dlp，规避 playurl 的 got TLS 风控 412）
 const getAcceptQuality = async (cid: string, bvid: string) => {
-  const SESSDATA = store.settingStore(pinia).SESSDATA
-  const bfeId = store.settingStore(pinia).bfeId
-  const config = {
-    headers: {
-      'User-Agent': `${UA}`,
-      cookie: `SESSDATA=${SESSDATA};bfe_id=${bfeId}`
-    },
-    responseType: 'json'
-  }
-  const { body: { data: { accept_quality, dash: { video, audio } } }, headers: { 'set-cookie': responseCookies } } = await window.electron.got(
-    `https://api.bilibili.com/x/player/playurl?cid=${cid}&bvid=${bvid}&qn=127&type=&otype=json&fourk=1&fnver=0&fnval=80&session=68191c1dc3c75042c6f35fba895d65b0`,
-    config
-  )
-  // 保存返回的cookies
-  saveResponseCookies(responseCookies)
-  return {
-    accept_quality,
-    video,
-    audio
-  }
+  return getYtdlpFormats(bvid)
 }
 
 // 获取指定清晰度视频下载地址
 const getDownloadUrl = async (cid: number, bvid: string, quality: number) => {
-  const SESSDATA = store.settingStore(pinia).SESSDATA
-  const bfeId = store.settingStore(pinia).bfeId
-  const config = {
-    headers: {
-      'User-Agent': `${UA}`,
-      // bfe_id必须要加
-      cookie: `SESSDATA=${SESSDATA};bfe_id=${bfeId}`
-    },
-    responseType: 'json'
-  }
+  await ensureBuvid3()
+  const query = await encWbi({ cid, bvid, qn: quality, fourk: 1, fnver: 0, fnval: 4048, ...genDmParams() })
   const { body: { data: { dash } }, headers: { 'set-cookie': responseCookies } } = await window.electron.got(
-    `https://api.bilibili.com/x/player/playurl?cid=${cid}&bvid=${bvid}&qn=${quality}&type=&otype=json&fourk=1&fnver=0&fnval=80&session=68191c1dc3c75042c6f35fba895d65b0`,
-    config
+    `https://api.bilibili.com/x/player/wbi/playurl?${query}`,
+    { headers: buildHeaders(), responseType: 'json' }
   )
   // 保存返回的cookies
   saveResponseCookies(responseCookies)
@@ -342,16 +449,11 @@ const getDownloadUrl = async (cid: number, bvid: string, quality: number) => {
 
 // 获取视频字幕
 const getSubtitle = async (cid: number, bvid: string) => {
-  const SESSDATA = store.settingStore(pinia).SESSDATA
-  const bfeId = store.settingStore(pinia).bfeId
-  const config = {
-    headers: {
-      'User-Agent': `${UA}`,
-      cookie: `SESSDATA=${SESSDATA};bfe_id=${bfeId}`
-    },
-    responseType: 'json'
-  }
-  const { body: { data: { subtitle } } } = await window.electron.got(`https://api.bilibili.com/x/player/v2?cid=${cid}&bvid=${bvid}`, config)
+  await ensureBuvid3()
+  const { body: { data: { subtitle } } } = await window.electron.got(
+    `https://api.bilibili.com/x/player/v2?cid=${cid}&bvid=${bvid}`,
+    { headers: buildHeaders(), responseType: 'json' }
+  )
   const subtitleList: Subtitle[] = subtitle.subtitles ? subtitle.subtitles.map((item: any) => ({ title: item.lan_doc, url: item.subtitle_url })) : []
   return subtitleList
 }

--- a/src/preload.js
+++ b/src/preload.js
@@ -19,6 +19,12 @@ contextBridge.exposeInMainWorld('electron', {
   gotBuffer (url, option) {
     return ipcRenderer.invoke('got-buffer', url, option)
   },
+  md5 (str) {
+    return ipcRenderer.invoke('md5', str)
+  },
+  ytdlpInfo (url, sessdata) {
+    return ipcRenderer.invoke('ytdlp-info', url, sessdata)
+  },
   getStore (path) {
     return ipcRenderer.invoke('get-store', path)
   },


### PR DESCRIPTION
## 背景

修复 #160 / #177 / #178 报告的 `解析错误：Error: Error: parse bv error`，以及排查中发现的 playurl 412 风控问题，恢复视频下载功能。项目自 v3.3.3（2022-07）停更后，B站多次改版导致解析全面失效。

## 问题排查

### 1. `parse bv error`
`src/core/bilibili.ts` 的 `parseBV` 用正则匹配网页内联的 `window.__INITIAL_STATE__`：

```js
const videoInfo = html.match(/\<\/script\>\<script\>window\.\_\_INITIAL\_STATE\_\_\=([\s\S]*?)\;\(function\(\)/)
if (!videoInfo) throw new Error('parse bv error')
```

B站改版/风控时返回的 HTML 不含该字段（或结构变化），正则失配即抛错，且**元信息解析没有任何 API 兜底**。

### 2. playurl 412（更深层的根因）
把 `parseBV` 改用官方 `x/web-interface/view` API 后（view 接口能过风控），发现 **playurl 接口（`x/player/wbi/playurl`）即使带齐 wbi 签名 + buvid3 + dm_params + Origin + fnval 4048（完全对齐 yt-dlp 的请求特征）仍被 412**。

经对比验证（**同 IP、同参数**）：
- **Python `requests` 请求 playurl：HTTP 200，code:0** ✅
- **`got`（Node.js）请求 playurl：412** ❌

根因是 **`got` 库的 TLS/HTTP 指纹被 B站针对 playurl 接口风控**——B站对下载地址接口的反爬比视频信息接口严，会检测请求库指纹。view 接口宽容（got 能过），playurl 严格（got 被 412）。这**不是参数问题**，在 `got` 框架内无法逾越。

## 解决方案

| 环节 | 方案 |
|---|---|
| 视频元信息 | `parseBV` 改用 `x/web-interface/view` API（got 能过风控） |
| playurl/下载流 | 改用 **yt-dlp** 获取 dash（主进程 spawn `python -m yt_dlp -J`，Python 的 TLS 指纹能过） |
| 抗风控 | 新增 wbi 签名 + buvid3（本地生成）+ 完整浏览器头（Referer/Origin/Accept-Language） |
| 转圈 bug | `checkUrlRedirect` 加 try-catch 降级（网页 412 不再阻塞解析，`parseBV` 只需 URL 提取 BV） |

### 改动文件
- **`src/core/bilibili.ts`**：view API 解析 + wbi 工具块（`MIXIN_KEY_ENC_TAB`/`buildHeaders`/`ensureBuvid3`/`ensureWbiMixinKey`/`encWbi`/`genDmParams`）+ `getYtdlpFormats` + `checkUrlRedirect` 降级
- **`src/background.ts`**：新增 `md5`（wbi 签名用 Node crypto）+ `ytdlp-info`（spawn yt-dlp）ipc handler
- **`src/preload.js`**：contextBridge 暴露 `md5` + `ytdlpInfo`

### 解析架构
```
parseBV → getViewInfo(view API，got 请求)
        → getAcceptQuality(yt-dlp 拿 dash，绕过 got 的 TLS 指纹墙)
        → getDownloadList(复用 dash 地址，下载走 bilivideo.com 不触发风控)
```

## 测试情况

- ✅ **view API**：正确拿到视频元信息（标题/cid/分P/UP主/stat）
- ✅ **yt-dlp playurl**：正确拿到 dash 视频/音频流（accept_quality + video/audio）
- ✅ **完整流程**：`npm run electron:serve` 启动 dev 客户端，解析视频 + 下载成功（登录态下高清）
- ✅ **Python 复现验证**：用 `requests` 以完全相同的参数（wbi + buvid3 + dm_params）请求 playurl 返回 code:0，证明参数正确、412 是 `got` 库的 TLS 指纹问题

## 已知限制 & 讨论

1. **playurl 依赖 Python yt-dlp**：`ytdlp-info` 通过 `python -m yt_dlp` 调用。打包发布时终端用户机器需有 Python + yt-dlp，否则 playurl 失败。更优雅的替代方案（受限于 `got` 的 TLS 指纹墙，纯 `got` 方案无法实现，故先用 yt-dlp 保证可用）：
   - 捆绑独立 `yt-dlp.exe`（PyInstaller 单文件，终端用户无需装 Python）
   - 或改用 Node 的 TLS 指纹模拟库（如 curl-impersonate 的 Node 绑定）
2. **多 P 视频**：单 P 完全可用（复用 dash）；多 P 的 `getDownloadUrl` 仍是 `got`（可能 412），如需要可后续改 yt-dlp。
3. wbi 算法参考 [bilibili-API-collect](https://github.com/SocialSisterYi/bilibili-API-collect)；dm_params / 本地 buvid3 策略参考 [yt-dlp](https://github.com/yt-dlp/yt-dlp) 的 bilibili extractor。

---

Closes #160, #177, #178.
